### PR TITLE
(#3) feat: context-aware detection for vague-quantifier and unbounded-scope

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,7 +3,12 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { readdirSync, statSync, existsSync, readFileSync } from 'fs';
-import { resolve, join, relative } from 'path';
+import { resolve, join, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const _pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as { version: string };
+const VERSION = `v${_pkg.version}`;
 import { lint, lintWithFix, DEFAULT_CONFIG, loadConfig } from '../src/index.js';
 import { runInteractive } from '../src/interactive/index.js';
 import { runClaudeSuggest, printClaudeCommand } from '../src/suggest/index.js';
@@ -16,7 +21,7 @@ const program = new Command();
 program
   .name('cclint')
   .description('AI 커맨드를 위한 Linter — 모호성을 검출하고 결정론성을 높인다')
-  .version('0.1.0');
+  .version(VERSION);
 
 // ─── cclint [command|path] ───────────────────────────────────────────────
 
@@ -114,7 +119,7 @@ async function lintDirectory(
   }
 
   console.log('');
-  console.log(chalk.bold('CcLint') + chalk.dim(' v0.1.0'));
+  console.log(chalk.bold('CcLint') + chalk.dim(` ${VERSION}`));
   console.log(chalk.dim(`디렉토리: ${dir}`));
   console.log(chalk.dim(`대상 파일: ${mdFiles.length}개 (*.${exts.join(', *.')})`));
   console.log('');
@@ -304,7 +309,7 @@ async function handleClaudeSuggest(input: string, result: LintResult, execute: b
 function printResult(result: LintResult): void {
   console.log('');
   console.log(chalk.dim('─'.repeat(60)));
-  console.log(chalk.bold('CcLint') + chalk.dim(' v0.1.0'));
+  console.log(chalk.bold('CcLint') + chalk.dim(` ${VERSION}`));
   console.log(chalk.dim('─'.repeat(60)));
   console.log(chalk.dim('입력: ') + chalk.italic(`"${result.command}"`));
   console.log('');

--- a/src/rules/built-in/missing-constraint.ts
+++ b/src/rules/built-in/missing-constraint.ts
@@ -11,6 +11,7 @@ const CONSTRAINT_HINTS: Record<string, string> = {
   environment: '환경을 명시하세요 (예: "production", "staging")',
   strategy: '전략을 명시하세요 (예: "blue-green", "rolling")',
   scope: '범위를 명시하세요 (예: "auth 모듈")',
+  style: '코드 스타일을 명시하세요 (예: "eslint-airbnb", "prettier")',
   pattern: '패턴을 명시하세요 (예: "factory method")',
   'source-language': '원본 언어를 명시하세요 (예: "한국어")',
   'target-language': '번역 대상 언어를 명시하세요 (예: "영어")',

--- a/src/rules/built-in/unbounded-scope.ts
+++ b/src/rules/built-in/unbounded-scope.ts
@@ -1,12 +1,32 @@
 import type { Rule, CommandAST, LintMessage } from '../../types.js';
 import { SCOPE_UNBOUNDED_KEYWORDS } from '../../parser/tokenizer.js';
 
+/**
+ * 커맨드에 구체적인 경로/파일/모듈이 명시되어 있으면 true
+ * 예: "src/auth/** 모든 파일" → "src/auth/**" 이 있으므로 실제로는 범위 한정됨
+ */
+function hasSpecificScope(raw: string): boolean {
+  // 파일 경로 패턴: src/, lib/, *.ts, /path/to/ 등
+  if (/(?:src|lib|dist|test|spec|app|components|pages|api|utils|hooks|store|services)\//.test(raw)) return true;
+  // glob 패턴: *.ts, **/*.js 등
+  if (/[*?]\.\w{1,4}/.test(raw)) return true;
+  // 파일 확장자 직접 명시: foo.ts, bar.py 등
+  if (/\w+\.(?:ts|js|tsx|jsx|py|go|rs|java|vue|svelte|css|scss)\b/.test(raw)) return true;
+  // 슬래시 포함 경로: /auth, /users 등
+  if (/\/\w{2,}/.test(raw)) return true;
+  return false;
+}
+
 export const unboundedScopeRule: Rule = {
   id: 'unbounded-scope',
   description: '범위 제한 없는 지시를 검출합니다',
 
   check(ast: CommandAST): LintMessage[] {
     const messages: LintMessage[] = [];
+
+    // 문맥 확인: 구체적인 경로/파일이 이미 명시되어 있으면 "모든/전체"는 그 범위를 수식하는 것
+    // 예: "src/auth/** 모든 파일 리뷰해줘" → 실제 범위는 src/auth/**로 한정
+    if (hasSpecificScope(ast.raw)) return messages;
 
     // scope 토큰이 unbounded 키워드로 시작하는 경우
     if (ast.scope) {
@@ -18,7 +38,7 @@ export const unboundedScopeRule: Rule = {
             severity: 'warn',
             message: `"${kw}" — 범위 무제한`,
             detail: '구체적인 경로, 모듈, 또는 조건으로 제한하세요 (예: "src/auth/**", "로그인 관련 파일만")',
-            fixable: true,
+            fixable: false,
           });
           return messages; // 하나만 보고
         }
@@ -34,7 +54,7 @@ export const unboundedScopeRule: Rule = {
           severity: 'warn',
           message: `"${kw}" — 범위가 과도하게 넓음`,
           detail: '구체적인 범위를 지정하세요',
-          fixable: true,
+          fixable: false,
         });
         break;
       }

--- a/src/rules/built-in/vague-quantifier.ts
+++ b/src/rules/built-in/vague-quantifier.ts
@@ -1,4 +1,4 @@
-import type { Rule, CommandAST, LintMessage } from '../../types.js';
+import type { Rule, CommandAST, LintMessage, ASTNode } from '../../types.js';
 
 // ─── 모호한 정량 표현 사전 ───────────────────────────────────────────────────
 // 정량적 기준 없이 사용된 수량/정도 표현을 검출
@@ -15,6 +15,20 @@ const VAGUE_QUANTIFIERS = new Set([
   'many', 'few', 'fast', 'slow', 'large', 'small', 'high', 'low',
   'sufficient', 'some',
 ]);
+
+// 숫자 + 단위 패턴 (구체적인 수치로 이미 명시된 경우)
+const NUMERIC_UNIT = /\d+\s*(ms|s|초|분|시간|개|명|건|회|번|mb|gb|kb|tb|%|px|em|rem|자|줄|행|열|배|이상|미만|이내|이하)/i;
+
+/**
+ * 해당 노드 주변(±60자)에 구체적인 수치 표현이 있으면 true
+ * 예: "빠른 응답을 위해 TTL을 100ms로" → "빠른" 근처에 "100ms" 존재
+ */
+function isContextualized(node: ASTNode, raw: string): boolean {
+  const window = 60;
+  const start = Math.max(0, node.position.start - window);
+  const end = Math.min(raw.length, node.position.end + window);
+  return NUMERIC_UNIT.test(raw.slice(start, end));
+}
 
 export const vagueQuantifierRule: Rule = {
   id: 'vague-quantifier',
@@ -33,17 +47,21 @@ export const vagueQuantifierRule: Rule = {
         : VAGUE_QUANTIFIERS.has(raw) ? raw
         : null;
 
-      if (matched && !seen.has(matched)) {
-        seen.add(matched);
-        const display = raw || normalized;
-        messages.push({
-          ruleId: 'vague-quantifier',
-          severity: 'warn',
-          message: `"${display}" — 정량 기준 없음`,
-          detail: `"${display}"은 구체적인 수치로 대체하세요 (예: "100개 이상", "500ms 이내", "10MB 미만")`,
-          fixable: true,
-        });
-      }
+      if (!matched || seen.has(matched)) continue;
+
+      // 문맥 확인: 근처에 구체적인 수치가 있으면 건너뜀
+      // 예: "빠른 응답 (100ms 이내)" → 이미 수치가 명시됨
+      if (isContextualized(node, ast.raw)) continue;
+
+      seen.add(matched);
+      const display = raw || normalized;
+      messages.push({
+        ruleId: 'vague-quantifier',
+        severity: 'warn',
+        message: `"${display}" — 정량 기준 없음`,
+        detail: `"${display}"은 구체적인 수치로 대체하세요 (예: "100개 이상", "500ms 이내", "10MB 미만")`,
+        fixable: true,
+      });
     }
 
     return messages;

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -2,7 +2,12 @@ import chokidar from 'chokidar';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { readFileSync } from 'fs';
-import { relative, resolve } from 'path';
+import { relative, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const _pkg = JSON.parse(readFileSync(resolve(__dirname, '../../../package.json'), 'utf-8')) as { version: string };
+const VERSION = `v${_pkg.version}`;
 import { lintWithFix } from '../index.js';
 import type { CcLintConfig, LintResult, FixSuggestion } from '../types.js';
 
@@ -25,7 +30,7 @@ export function runWatch(dir: string, opts: WatchOptions): void {
   const patterns = opts.exts.map(ext => `${absDir}/**/*.${ext}`);
 
   console.log('');
-  console.log(chalk.bold('CcLint') + chalk.dim(' v0.1.1 — watch mode'));
+  console.log(chalk.bold('CcLint') + chalk.dim(` ${VERSION} — watch mode`));
   console.log(chalk.dim(`감시 중: ${absDir} (*.${opts.exts.join(', *.')})`));
   console.log(chalk.dim('파일이 저장되면 자동으로 lint합니다. Ctrl+C로 종료.\n'));
 


### PR DESCRIPTION
## Summary

- **vague-quantifier**: Skip flagging when a numeric constraint (e.g. `100ms`, `80%`) exists near the vague word — `"빠른 응답을 위해 TTL을 100ms로"` no longer triggers false positive
- **unbounded-scope**: Skip flagging when a specific path/file pattern is present — `"src/auth/** 모든 파일"` correctly passes
- **Dynamic version**: Read from `package.json` instead of hardcoded `v0.1.0`/`v0.1.1`
- **Fix**: `unbounded-scope` `fixable → false` (fixer had no scope-specific logic)
- **Fix**: Add missing `style` hint in `missing-constraint` rule

## Test plan

- [ ] `"빠른 응답을 위해 TTL을 100ms로 설정해줘"` → ✔ 문제 없음
- [ ] `"빠른 응답으로 설정해줘"` → ⚠️ 빠른 — 정량 기준 없음
- [ ] `"src/auth/** 모든 파일 리뷰해줘"` → ✔ 문제 없음
- [ ] `"모든 파일 수정해줘"` → ⚠️ 모든 — 범위가 과도하게 넓음
- [ ] `cclint --version` → `0.3.0`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)