### PR TITLE
(#5) chore: sync package-lock.json to v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandlint",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandlint",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",


### PR DESCRIPTION
## Summary

- Sync `package-lock.json` version to match `v0.4.0` after version bump

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)