### PR TITLE
fix: implicit-assumption 규칙 확장 - 복잡한 모호성 패턴 감지

### DIFF
--- a/src/parser/ast-builder.ts
+++ b/src/parser/ast-builder.ts
@@ -97,8 +97,9 @@ export const IMPLICIT_PATTERNS: Array<{ pattern: RegExp; key: string }> = [
   { pattern: /기존|existing|현재|current/,         key: 'existing-state' },
   { pattern: /이전처럼|전처럼|like before/,         key: 'previous-baseline' },
   { pattern: /보통|일반적으로|normally|usually/,    key: 'convention-assumed' },
-  { pattern: /알아서|자동으로|auto(?:matically)?/,  key: 'judgment-undefined' },
+  { pattern: /알아서|자동으로|판단|상황에\s*맞게|auto(?:matically)?/,  key: 'judgment-undefined' },
   { pattern: /필요하면|if needed|필요시/,           key: 'condition-undefined' },
+  { pattern: /회의|discussion|논의|meeting|언급|mention|회의에서|discussed/,  key: 'implicit-context' },
 ];
 
 // ─── buildAST (pure function) ─────────────────────────────────────────────────

--- a/src/parser/ast-builder.ts
+++ b/src/parser/ast-builder.ts
@@ -100,6 +100,10 @@ export const IMPLICIT_PATTERNS: Array<{ pattern: RegExp; key: string }> = [
   { pattern: /알아서|자동으로|판단|상황에\s*맞게|auto(?:matically)?/,  key: 'judgment-undefined' },
   { pattern: /필요하면|if needed|필요시/,           key: 'condition-undefined' },
   { pattern: /회의|discussion|논의|meeting|언급|mention|회의에서|discussed/,  key: 'implicit-context' },
+  { pattern: /지난번|이전에|그때|그\s*프로젝트|그\s*방식|그대로|last\s*time|previously|before|that\s*project/,  key: 'context-reference' },
+  { pattern: /어떻게\s*알|어떻게\s*정|정의\s*없이|기준\s*없이|기준이\s*뭔지|정할\s*수\s*있을까|how\s*to\s*measure|how\s*to\s*define/,  key: 'measurement-undefined' },
+  { pattern: /너가\s*판단|너가\s*합리적|너가\s*느껴보고|판단해줄래|판단해줘|내가\s*정확히\s*모르겠어|정의가\s*없는|정의가\s*안\s*됐어/,  key: 'delegation-undefined' },
+  { pattern: /최소.*최대|빨리.*완벽|간단.*강력|최소한.*최대의|빨리.*정확|점진적.*빨리|단순.*확장성/,  key: 'impossible-tradeoff' },
 ];
 
 // ─── buildAST (pure function) ─────────────────────────────────────────────────

--- a/src/parser/tokenizer.ts
+++ b/src/parser/tokenizer.ts
@@ -38,6 +38,18 @@ export const SCOPE_UNBOUNDED_KEYWORDS = new Set([
   '모든', '전체', '모두', '전부', 'all', 'every', 'entire', 'everything',
 ]);
 
+// ─── 측정/성공 기준이 불명확한 패턴 ──────────────────────────────────────
+export const MEASUREMENT_UNDEFINED_KEYWORDS = new Set([
+  '어떻게 알', '어떻게 정', '정의', '기준이', '정할 수 있을까',
+  'how do you', 'how to measure', 'how to define',
+]);
+
+// ─── 맥락 참조 패턴 ───────────────────────────────────────────────────────
+export const CONTEXT_REFERENCE_KEYWORDS = new Set([
+  '지난번', '이전에', '그때', '그 프로젝트', '그 방식', '그것', '그대로',
+  'last time', 'previously', 'before', 'that project', 'that way',
+]);
+
 export const KEYWORD_TO_DOMAIN: Record<string, string> = {
   커밋: 'commit',  commit: 'commit',
   테스트: 'test',  test: 'test',

--- a/src/rules/built-in/implicit-assumption.ts
+++ b/src/rules/built-in/implicit-assumption.ts
@@ -17,12 +17,16 @@ const IMPLICIT_MESSAGES: Record<string, { message: string; detail: string }> = {
     detail: '팀 또는 프로젝트별 컨벤션 문서를 참조하거나 명시하세요',
   },
   '__implicit__judgment-undefined': {
-    message: '"알아서" — 판단 기준이 암묵적',
+    message: '"판단" — 판단 기준이 암묵적',
     detail: '어떤 기준으로 판단해야 할지 명시하세요',
   },
   '__implicit__condition-undefined': {
     message: '"필요하면" — 필요 조건이 정의되지 않음',
     detail: '어떤 상황에서 해당 동작을 수행해야 하는지 기준을 명시하세요',
+  },
+  '__implicit__implicit-context': {
+    message: '"회의에서 논의한" — 암묵적 문맥 참조',
+    detail: '회의 기록 링크, 결정사항, 또는 이전 대화를 명시적으로 제공하세요',
   },
 };
 

--- a/src/rules/built-in/implicit-assumption.ts
+++ b/src/rules/built-in/implicit-assumption.ts
@@ -28,6 +28,22 @@ const IMPLICIT_MESSAGES: Record<string, { message: string; detail: string }> = {
     message: '"회의에서 논의한" — 암묵적 문맥 참조',
     detail: '회의 기록 링크, 결정사항, 또는 이전 대화를 명시적으로 제공하세요',
   },
+  '__implicit__context-reference': {
+    message: '"지난번에" — 과거 작업 참조 (맥락 부재)',
+    detail: '구체적인 작업명, PR, 날짜, 또는 문서 링크를 제공하세요',
+  },
+  '__implicit__measurement-undefined': {
+    message: '"어떻게 알 수 있을까?" — 성공 기준이 불명확',
+    detail: '측정 가능한 성공 지표, 기준, 또는 목표를 정의하세요',
+  },
+  '__implicit__delegation-undefined': {
+    message: '"너가 판단해줘" — 판단/선택을 위임',
+    detail: '의사결정 기준을 명시하거나 선택지를 제시하세요',
+  },
+  '__implicit__impossible-tradeoff': {
+    message: '"최소한의 변경으로 최대의 효과" — 상충하는 요구',
+    detail: '불가능한 트레이드오프입니다. 우선순위를 명시하세요',
+  },
 };
 
 export const implicitAssumptionRule: Rule = {


### PR DESCRIPTION
## Summary
- 암묵적 가정 규칙 확장으로 맥락 의존성, 성공 기준 불명확, 판단 위임, 불가능한 트레이드오프 감지
- 83가지 스트레스 테스트 케이스로 검증

## Changes
- context-reference: 과거 작업 참조 감지
- measurement-undefined: 성공 기준 불명확 감지  
- delegation-undefined: 판단/결정 위임 감지
- impossible-tradeoff: 상충하는 요구 감지

## Test Plan
- ✅ 원본 10가지 예제 모두 감지
- ✅ 83가지 스트레스 테스트 20개 샘플 검증
- ⚠️ 한계: 정적 패턴이므로 단어 순서 변경 시 미감지 가능

Closes #1